### PR TITLE
Add to plugin namespace

### DIFF
--- a/includes/QAutocomplete2.php
+++ b/includes/QAutocomplete2.php
@@ -1,4 +1,5 @@
 <?php
+	namespace QCubed\Plugin\QAutocomplete2;
 	class QAutocomplete2 extends QAutocompleteBase
 	{
 		/** @var boolean */
@@ -147,4 +148,3 @@
 			));
 		}
 	}
-?>


### PR DESCRIPTION
Bootstrap plugin uses namespaces, autocomplete doesn't. 
Shouldn't we add this?